### PR TITLE
Remove Rimango from SqlitePclPluginBootstrap.cs.pp

### DIFF
--- a/nuspec/TouchBootstrapContent/SqlitePclPluginBootstrap.cs.pp
+++ b/nuspec/TouchBootstrapContent/SqlitePclPluginBootstrap.cs.pp
@@ -3,6 +3,6 @@
 namespace $rootnamespace$.Bootstrap
 {
     public class SqlitePluginBootstrap
-        : MvxPluginBootstrapAction<Rimango.MvvmCross.Plugins.Sqlite.PluginLoader, Rimango.MvvmCross.Plugins.Sqlite.Touch.Plugin>
+        : MvxLoaderPluginBootstrapAction<MvvmCross.Plugins.Sqlite.PluginLoader, MvvmCross.Plugins.Sqlite.Touch.Plugin>
 	{}
 }


### PR DESCRIPTION
Removed Rimango from namespace in Touch bootstrapper for SQLitePCL.
