### PR TITLE
Fixed crash when caching multiple images from same source

### DIFF
--- a/DownloadCache/MvvmCross.Plugins.DownloadCache/MvxImageCache.cs
+++ b/DownloadCache/MvvmCross.Plugins.DownloadCache/MvxImageCache.cs
@@ -53,10 +53,12 @@ namespace MvvmCross.Plugins.DownloadCache
                     _fileDownloadCache.RequestLocalFilePath(url, 
                         async s => {
                             var image = await Parse(s).ConfigureAwait(false);
-							if(!_entriesByHttpUrl.ContainsKey(url)) {
-                            	_entriesByHttpUrl.Add(url, new Entry(url, image));
-							}
-
+                            lock(_entriesByHttpUrl)
+                            {
+    							if(!_entriesByHttpUrl.ContainsKey(url)) {
+                                	_entriesByHttpUrl.Add(url, new Entry(url, image));
+    							}
+                            }
                             tcs.TrySetResult(image.RawImage);
                         },
                         exception => {


### PR DESCRIPTION
Encountered an issue with download cache when using the same image path on multiple ImageViews.
Added lock on _entriesByHttpUrl since it is accessed from multiple threads.
