### PR TITLE
Fixed folder path ended by a separator not properly handled on WindowsUWP

### DIFF
--- a/File/MvvmCross.Plugins.File.WindowsCommon/MvxWindowsCommonFileStore.cs
+++ b/File/MvvmCross.Plugins.File.WindowsCommon/MvxWindowsCommonFileStore.cs
@@ -158,7 +158,14 @@ namespace MvvmCross.Plugins.File.WindowsCommon
             if (string.IsNullOrEmpty(folderPath))
                 return rootFolder;
             var currentFolder = await CreateFolderAsync(rootFolder, Path.GetDirectoryName(folderPath)).ConfigureAwait(false);
-            return await currentFolder.CreateFolderAsync(Path.GetFileName(folderPath), CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false);
+
+            //folder name may be empty if original path was ended by a separator like My/Custom/Path/ instead of My/Custom/Path
+            var folderName = Path.GetFileName(folderPath);
+            if (string.IsNullOrEmpty(folderName))
+                return currentFolder;
+            else
+                return await currentFolder.CreateFolderAsync(Path.GetFileName(folderPath), CreationCollisionOption.OpenIfExists).AsTask().ConfigureAwait(false);
+
         }
 
         public override IEnumerable<string> GetFilesIn(string folderPath)


### PR DESCRIPTION
While creating folders with `EnsureFolderExists()`, if the path is ended by a separator (like `Path/To/My/Folder/`) then this will result in a FileNotFoundException due to trying to create a folder with an empty name.
This exception does not occur on Android and iOS for the exact same path.
