### PR TITLE
Fixed WindowsUWP runtime directives file not properly referenced

### DIFF
--- a/SQLite-PCL/MvvmCross.Plugins.Sqlite.WindowsUWP/MvvmCross.Plugins.Sqlite.WindowsUWP.csproj
+++ b/SQLite-PCL/MvvmCross.Plugins.Sqlite.WindowsUWP/MvvmCross.Plugins.Sqlite.WindowsUWP.csproj
@@ -116,7 +116,7 @@
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WindowsSqliteConnectionFactory.cs" />
-    <Content Include="Properties\MvvmCross.Plugins.Sqlite.UWP.rd.xml" />
+    <Content Include="Properties\MvvmCross.Plugins.Sqlite.WindowsUWP.rd.xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MvvmCross.Plugins.Sqlite\MvvmCross.Plugins.Sqlite.csproj">

--- a/SQLite-PCL/MvvmCross.Plugins.Sqlite.WindowsUWP/Properties/MvvmCross.Plugins.Sqlite.WindowsUWP.rd.xml
+++ b/SQLite-PCL/MvvmCross.Plugins.Sqlite.WindowsUWP/Properties/MvvmCross.Plugins.Sqlite.WindowsUWP.rd.xml
@@ -22,12 +22,12 @@
         types or methods decorated with an attribute.
 
     For more information on writing Runtime Directives for libraries, please visit
-    http://go.microsoft.com/fwlink/?LinkId=613100
+    http://go.microsoft.com/fwlink/?LinkID=391919
 -->
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
-  <Library Name="MvvmCross.Plugins.Sqlite.UWP">
+  <Library Name="MvvmCross.Plugins.Sqlite.WindowsUWP">
 
-  	<!-- add directives for your library here -->
+    <!-- add directives for your library here -->
 
   </Library>
 </Directives>

--- a/SQLite-PCL/MvvmCross.Plugins.Sqlite.WindowsUWP/project.lock.json
+++ b/SQLite-PCL/MvvmCross.Plugins.Sqlite.WindowsUWP/project.lock.json
@@ -12392,7 +12392,7 @@
       ]
     },
     "MvvmCross.Platform/4.0.0-beta8": {
-      "sha512": "mMDRqDaOjb87DdgKWaGEPC5OeeYjXklIVZNmpEJCPD1aA1B5Jba8jAvV4Hqjk/eRPJ6JDBrS8/z9bfbw+foGrw==",
+      "sha512": "xqdwYHnTJFnAPdt2n2Kyw+aJkHt2S5q6kic6J1k9yVP+z2SI4Styp1x91+QN7Yg/ALFhEvhTc8EkARaghNyZfw==",
       "type": "Package",
       "files": [
         "[Content_Types].xml",


### PR DESCRIPTION
There is no real issue here... mostly to keep things clean :)
I spotted it while working on 3fd7ddd55dcb686cc05aa595aaa0c84cc8cb9bae
