### PR TITLE
Fix Android crash related to bitmaps cleanup in MvxImageCache

### DIFF
--- a/DownloadCache/MvvmCross.Plugins.DownloadCache/MvvmCross.Plugins.DownloadCache.csproj
+++ b/DownloadCache/MvvmCross.Plugins.DownloadCache/MvvmCross.Plugins.DownloadCache.csproj
@@ -39,27 +39,26 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions">
       <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net45+win8+wp8+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="MvvmCross.Binding, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MvvmCross.Binding.4.0.0\lib\portable-net45+win+wpa81+wp80\MvvmCross.Binding.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="MvvmCross.Core, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MvvmCross.Core.4.0.0\lib\portable-net45+win+wpa81+wp80\MvvmCross.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="MvvmCross.Localization, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MvvmCross.Binding.4.0.0\lib\portable-net45+win+wpa81+wp80\MvvmCross.Localization.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="MvvmCross.Platform, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MvvmCross.Platform.4.0.0\lib\portable-net45+win+wpa81+wp80\MvvmCross.Platform.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
+    <Reference Include="MvvmCross.Binding, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MvvmCross.Binding.4.0.0\lib\portable-net45+win+wpa81+wp80\MvvmCross.Binding.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MvvmCross.Core.4.0.0\lib\portable-net45+win+wpa81+wp80\MvvmCross.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Localization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MvvmCross.Binding.4.0.0\lib\portable-net45+win+wpa81+wp80\MvvmCross.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Platform, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MvvmCross.Platform.4.0.0\lib\portable-net45+win+wpa81+wp80\MvvmCross.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IMvxFileDownloadCache.cs" />

--- a/DownloadCache/MvvmCross.Plugins.DownloadCache/MvxImageCache.cs
+++ b/DownloadCache/MvvmCross.Plugins.DownloadCache/MvxImageCache.cs
@@ -11,6 +11,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Collections.Immutable;
+using System.Threading;
 
 namespace MvvmCross.Plugins.DownloadCache
 {
@@ -18,7 +20,7 @@ namespace MvvmCross.Plugins.DownloadCache
         : MvxAllThreadDispatchingObject
         , IMvxImageCache<T>
     {
-        private readonly Dictionary<string, Entry> _entriesByHttpUrl = new Dictionary<string, Entry>();
+        private ImmutableDictionary<string, Entry> _entriesByHttpUrl = ImmutableDictionary.Create<string, Entry>();
 
         private readonly IMvxFileDownloadCache _fileDownloadCache;
         private readonly int _maxInMemoryBytes;
@@ -55,13 +57,8 @@ namespace MvvmCross.Plugins.DownloadCache
                         async s =>
                         {
                             var image = await Parse(s).ConfigureAwait(false);
-                            lock (_entriesByHttpUrl)
-                            {
-                                if (!_entriesByHttpUrl.ContainsKey(url))
-                                {
-                                    _entriesByHttpUrl.Add(url, new Entry(url, image));
-                                }
-                            }
+                            var entriesByUrl = _entriesByHttpUrl.SetItem (url, new Entry(url, image));
+                            Interlocked.Exchange (ref _entriesByHttpUrl, entriesByUrl);
                             tcs.TrySetResult(image.RawImage);
                         },
                         exception =>
@@ -84,22 +81,23 @@ namespace MvvmCross.Plugins.DownloadCache
         {
             RunSyncOrAsyncWithLock(() =>
             {
-                var currentSizeInBytes = _entriesByHttpUrl.Values.Sum(x => x.Image.GetSizeInBytes());
-                var currentCountFiles = _entriesByHttpUrl.Values.Count;
+                var entries = _entriesByHttpUrl.Select (kvp => kvp.Value).ToList ();
+
+                var currentSizeInBytes = entries.Sum(x => x.Image.GetSizeInBytes());
+                var currentCountFiles = entries.Count;
 
                 if (currentCountFiles <= _maxInMemoryFiles
                     && currentSizeInBytes <= _maxInMemoryBytes)
                     return;
 
                 // we don't use LINQ OrderBy here because of AOT/JIT problems on MonoTouch
-                List<Entry> sortedEntries = _entriesByHttpUrl.Values.ToList();
-                sortedEntries.Sort(new MvxImageComparer());
+                entries.Sort(new MvxImageComparer());
 
                 while (currentCountFiles > _maxInMemoryFiles
                         || currentSizeInBytes > _maxInMemoryBytes)
                 {
-                    var toRemove = sortedEntries[0];
-                    sortedEntries.RemoveAt(0);
+                    var toRemove = entries[0];
+                    entries.RemoveAt(0);
 
                     currentSizeInBytes -= toRemove.Image.GetSizeInBytes();
                     currentCountFiles--;
@@ -107,7 +105,8 @@ namespace MvvmCross.Plugins.DownloadCache
                     if (_disposeOnRemove)
                         toRemove.Image.RawImage.DisposeIfDisposable();
 
-                    _entriesByHttpUrl.Remove(toRemove.Url);
+                    var entriesByUrl = _entriesByHttpUrl.Remove (toRemove.Url);
+                    Interlocked.Exchange (ref _entriesByHttpUrl, entriesByUrl);
                 }
             });
         }

--- a/DownloadCache/MvvmCross.Plugins.DownloadCache/packages.config
+++ b/DownloadCache/MvvmCross.Plugins.DownloadCache/packages.config
@@ -6,4 +6,5 @@
   <package id="MvvmCross.Binding" version="4.0.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="MvvmCross.Core" version="4.0.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="MvvmCross.Platform" version="4.0.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable-net45+win+wpa81+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
 </packages>


### PR DESCRIPTION
Fix to https://github.com/MvvmCross/MvvmCross-Plugins/issues/41
- Use ImmutableDictionary to synchronise operations on entries
- Dispose images on MainThread
