### PR TITLE
Allow pictureavailable method to get selected image display name.

### DIFF
--- a/PictureChooser/MvvmCross.Plugins.PictureChooser.WindowsCommon/MvxPictureChooserTask.cs
+++ b/PictureChooser/MvvmCross.Plugins.PictureChooser.WindowsCommon/MvxPictureChooserTask.cs
@@ -24,10 +24,10 @@ namespace MvvmCross.Plugins.PictureChooser.WindowsPhoneStore
     {
         private int _maxPixelDimension;
         private int _percentQuality;
-        private Action<Stream> _pictureAvailable;
+        private Action<Stream, string> _pictureAvailable;
         private Action _assumeCancelled;
 
-        public void ChoosePictureFromLibrary(int maxPixelDimension, int percentQuality, Action<Stream> pictureAvailable, Action assumeCancelled)
+        public void ChoosePictureFromLibrary(int maxPixelDimension, int percentQuality, Action<Stream, string> pictureAvailable, Action assumeCancelled)
         {
             // This method requires that PickFileContinuation is implemented within the Windows Phone project and that
             // the ContinueFileOpenPicker method on the View invokes (via the ViewModel) the ContinueFileOpenPicker method
@@ -41,6 +41,11 @@ namespace MvvmCross.Plugins.PictureChooser.WindowsPhoneStore
             _assumeCancelled = assumeCancelled;
 
             PickStorageFileFromDisk();
+        }
+
+        public void ChoosePictureFromLibrary(int maxPixelDimension, int percentQuality, Action<Stream> pictureAvailable, Action assumeCancelled)
+        {
+            this.ChoosePictureFromLibrary(maxPixelDimension, percentQuality, (stream, name) => pictureAvailable(stream), assumeCancelled);
         }
 
         public void ContinueFileOpenPicker(object args)
@@ -57,7 +62,7 @@ namespace MvvmCross.Plugins.PictureChooser.WindowsPhoneStore
                         var resizedStream =
                             await ResizeJpegStreamAsync(_maxPixelDimension, _percentQuality, rawFileStream);
 
-                        _pictureAvailable?.Invoke(resizedStream.AsStreamForRead());
+                        _pictureAvailable?.Invoke(resizedStream.AsStreamForRead(), continuationArgs.Files[0].DisplayName);
                     });
             }
             else

--- a/PictureChooser/MvvmCross.Plugins.PictureChooser/IMvxCombinedPictureChooserTask.cs
+++ b/PictureChooser/MvvmCross.Plugins.PictureChooser/IMvxCombinedPictureChooserTask.cs
@@ -12,7 +12,7 @@ namespace MvvmCross.Plugins.PictureChooser
 {
     public interface IMvxCombinedPictureChooserTask
     {
-        void ChooseOrTakePicture(int maxPixelDimension, int percentQuality, Action<Stream> pictureAvailable,
+        void ChooseOrTakePicture(int maxPixelDimension, int percentQuality, Action<Stream, string> pictureAvailable,
                                  Action assumeCancelled);
     }
 }

--- a/PictureChooser/MvvmCross.Plugins.PictureChooser/IMvxPictureChooserTask.cs
+++ b/PictureChooser/MvvmCross.Plugins.PictureChooser/IMvxPictureChooserTask.cs
@@ -13,9 +13,33 @@ namespace MvvmCross.Plugins.PictureChooser
 {
     public interface IMvxPictureChooserTask
     {
+        /// <summary>
+        /// Allow to Choose a picture from library.
+        /// </summary>
+        /// <param name="maxPixelDimension">The maximum pixel dimension.</param>
+        /// <param name="percentQuality">The quality in percent.</param>
+        /// <param name="pictureAvailable">Action to invoke when picture is available. Where parameters are the picture stream and picture display name.</param>
+        /// <param name="assumeCancelled">Action to invoke on cancellation</param>
+        void ChoosePictureFromLibrary(int maxPixelDimension, int percentQuality, Action<Stream, string> pictureAvailable,
+                                      Action assumeCancelled);
+
+        /// <summary>
+        /// Allow to Choose a picture from library.
+        /// </summary>
+        /// <param name="maxPixelDimension">The maximum pixel dimension.</param>
+        /// <param name="percentQuality">The quality in percent.</param>
+        /// <param name="pictureAvailable">Action to invoke when picture is available.</param>
+        /// <param name="assumeCancelled">Action to invoke on cancellation</param>
         void ChoosePictureFromLibrary(int maxPixelDimension, int percentQuality, Action<Stream> pictureAvailable,
                                       Action assumeCancelled);
 
+        /// <summary>
+        /// Allow to take a picture using the device camera
+        /// </summary>
+        /// <param name="maxPixelDimension">Maximum pixel dimension.</param>
+        /// <param name="percentQuality">Image quality in percent.</param>
+        /// <param name="pictureAvailable"> Action to invoke when picture is available.</param>
+        /// <param name="assumeCancelled">Action to invoke on cancellation.</param>
         void TakePicture(int maxPixelDimension, int percentQuality, Action<Stream> pictureAvailable,
                          Action assumeCancelled);
 


### PR DESCRIPTION
New pull request from #74 

In some case user could need the selected file display name.
It's a little method addition who allow to use a PictureAvailable action with the file name in parameter.
