### PR TITLE
Implement Fused location plugin for Android

### DIFF
--- a/Location/MvvmCross.Plugins.Location.Fused.Droid/FusedLocationHandler.cs
+++ b/Location/MvvmCross.Plugins.Location.Fused.Droid/FusedLocationHandler.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using Android.OS;
+using Android.Content;
+using Android.Gms.Common;
+using Android.Gms.Common.Apis;
+using Android.Gms.Location;
+using MvvmCross.Platform.Platform;
+using MvvmCross.Platform.Exceptions;
+
+namespace MvvmCross.Plugins.Location.Fused.Droid
+{
+	public class FusedLocationHandler
+		: LocationCallback
+		, IGoogleApiClientConnectionCallbacks
+		, IGoogleApiClientOnConnectionFailedListener
+	{
+		private IGoogleApiClient _client;
+		private LocationRequest _request;
+
+		private readonly MvxAndroidFusedLocationWatcher _owner;
+
+		public FusedLocationHandler (MvxAndroidFusedLocationWatcher owner, Context context)
+		{
+			_owner = owner;
+			EnsureGooglePlayServiceAvailable (context);
+			Initialize (context);
+		}
+
+		public void Start (MvxLocationOptions options)
+		{
+			_request = CreateLocationRequest (options);
+			_client.Connect ();
+		}
+
+		public void Stop ()
+		{
+			if (_client == null) {
+				return;
+			}
+
+			LocationServices.FusedLocationApi.RemoveLocationUpdates(_client, this);
+
+			_client.Disconnect ();
+		}
+
+		public Android.Locations.Location GetLastKnownLocation ()
+		{
+			if (_client.IsConnected)
+			{
+				return LocationServices.FusedLocationApi.GetLastLocation(_client);
+			}
+			return null;
+		}
+
+		public void OnConnected (Bundle connectionHint)
+		{
+			var location = LocationServices.FusedLocationApi.GetLastLocation(_client);
+			if (location != null)
+			{
+				_owner.OnLocationUpdated (location);
+			}
+			LocationServices.FusedLocationApi.RequestLocationUpdates (_client, _request, this, Looper.MainLooper);
+		}
+
+		public void OnConnectionSuspended (int cause)
+		{
+			// disconnected
+			MvxTrace.Trace ("Plugin.Location.Fused.OnConnectionSuspended: " + cause);
+		}
+
+		public void OnConnectionFailed (ConnectionResult result)
+		{
+			_owner.OnLocationError (ToMvxLocationErrorCode (result));
+			MvxTrace.Trace ("Plugin.Location.Fused.OnConnectionFailed: " + result);
+		}
+
+		public override void OnLocationResult (LocationResult result)
+		{
+			_owner.OnLocationUpdated (result.LastLocation);
+		}
+
+		public override void OnLocationAvailability (LocationAvailability locationAvailability)
+		{
+			var available = locationAvailability != null && locationAvailability.IsLocationAvailable;
+			_owner.OnLocationAvailabilityChanged (available);
+		}
+
+		private void EnsureGooglePlayServiceAvailable (Context context)
+		{
+			var availability = GoogleApiAvailability.Instance;
+			var result = availability.IsGooglePlayServicesAvailable (context);
+			if (result != ConnectionResult.Success)
+			{
+				var errorMessage = "GooglePlayService is not available";
+				if (availability.IsUserResolvableError (result))
+				{
+					errorMessage = availability.GetErrorString (result);
+				}
+				throw new MvxException (errorMessage);
+			}
+		}
+
+		private void Initialize (Context context)
+		{
+			_client = new GoogleApiClientBuilder (context)
+				.AddApi (LocationServices.API)
+				.AddConnectionCallbacks (this)
+				.AddOnConnectionFailedListener (this)
+				.Build ();
+		}
+
+		private static LocationRequest CreateLocationRequest (MvxLocationOptions options)
+		{
+			// NOTE options.TrackingMode is not supported
+
+			var request = LocationRequest.Create ();
+
+			switch (options.Accuracy) {
+			case MvxLocationAccuracy.Fine:
+				request.SetPriority (LocationRequest.PriorityHighAccuracy);
+				break;
+			case MvxLocationAccuracy.Coarse:
+				request.SetPriority (LocationRequest.PriorityBalancedPowerAccuracy);
+				break;
+			default:
+				throw new ArgumentOutOfRangeException ();
+			}
+
+			request.SetInterval ((long)options.TimeBetweenUpdates.TotalMilliseconds);
+			request.SetSmallestDisplacement (options.MovementThresholdInM);
+
+			return request;
+		}
+
+		private static MvxLocationErrorCode ToMvxLocationErrorCode (ConnectionResult connectionResult)
+		{
+			var errorCode = connectionResult.ErrorCode;
+
+			if (errorCode == ConnectionResult.Timeout) {
+				return MvxLocationErrorCode.Timeout;
+			}
+
+			// TODO handle more error-codes?
+
+			return MvxLocationErrorCode.ServiceUnavailable;
+		}
+	}
+}
+

--- a/Location/MvvmCross.Plugins.Location.Fused.Droid/FusedLocationHandler.cs
+++ b/Location/MvvmCross.Plugins.Location.Fused.Droid/FusedLocationHandler.cs
@@ -54,12 +54,13 @@ namespace MvvmCross.Plugins.Location.Fused.Droid
 
 		public void OnConnected (Bundle connectionHint)
 		{
+			LocationServices.FusedLocationApi.RequestLocationUpdates (_client, _request, this, Looper.MainLooper);
+
 			var location = LocationServices.FusedLocationApi.GetLastLocation(_client);
 			if (location != null)
 			{
 				_owner.OnLocationUpdated (location);
 			}
-			LocationServices.FusedLocationApi.RequestLocationUpdates (_client, _request, this, Looper.MainLooper);
 		}
 
 		public void OnConnectionSuspended (int cause)

--- a/Location/MvvmCross.Plugins.Location.Fused.Droid/FusedLocationHandler.cs
+++ b/Location/MvvmCross.Plugins.Location.Fused.Droid/FusedLocationHandler.cs
@@ -11,10 +11,10 @@ namespace MvvmCross.Plugins.Location.Fused.Droid
 {
 	public class FusedLocationHandler
 		: LocationCallback
-		, IGoogleApiClientConnectionCallbacks
-		, IGoogleApiClientOnConnectionFailedListener
+		, GoogleApiClient.IConnectionCallbacks
+		, GoogleApiClient.IOnConnectionFailedListener
 	{
-		private IGoogleApiClient _client;
+		private GoogleApiClient _client;
 		private LocationRequest _request;
 
 		private readonly MvxAndroidFusedLocationWatcher _owner;
@@ -102,7 +102,7 @@ namespace MvvmCross.Plugins.Location.Fused.Droid
 
 		private void Initialize (Context context)
 		{
-			_client = new GoogleApiClientBuilder (context)
+			_client = new GoogleApiClient.Builder (context)
 				.AddApi (LocationServices.API)
 				.AddConnectionCallbacks (this)
 				.AddOnConnectionFailedListener (this)

--- a/Location/MvvmCross.Plugins.Location.Fused.Droid/MvvmCross.Plugins.Location.Fused.Droid.csproj
+++ b/Location/MvvmCross.Plugins.Location.Fused.Droid/MvvmCross.Plugins.Location.Fused.Droid.csproj
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>MvvmCross.Plugins.Location.Fused.Droid</RootNamespace>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
+    <AssemblyName>MvvmCross.Plugins.Location.Fused.Droid</AssemblyName>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidLinkMode>None</AndroidLinkMode>
+    <ConsolePause>false</ConsolePause>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <ConsolePause>false</ConsolePause>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Mono.Android" />
+    <Reference Include="Mono.Android.Export" />
+    <Reference Include="MvvmCross.Platform.Droid">
+      <HintPath>..\..\packages\MvvmCross.Platform.4.1.0\lib\MonoAndroid\MvvmCross.Platform.Droid.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Platform">
+      <HintPath>..\..\packages\MvvmCross.Platform.4.1.0\lib\MonoAndroid\MvvmCross.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Droid">
+      <HintPath>..\..\packages\MvvmCross.Core.4.1.0\lib\MonoAndroid\MvvmCross.Droid.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Core">
+      <HintPath>..\..\packages\MvvmCross.Core.4.1.0\lib\MonoAndroid\MvvmCross.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Binding.Droid">
+      <HintPath>..\..\packages\MvvmCross.Binding.4.1.0\lib\MonoAndroid\MvvmCross.Binding.Droid.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Binding">
+      <HintPath>..\..\packages\MvvmCross.Binding.4.1.0\lib\MonoAndroid\MvvmCross.Binding.dll</HintPath>
+    </Reference>
+    <Reference Include="MvvmCross.Localization">
+      <HintPath>..\..\packages\MvvmCross.Binding.4.1.0\lib\MonoAndroid\MvvmCross.Localization.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Android.Support.v4">
+      <HintPath>..\..\packages\Xamarin.Android.Support.v4.23.0.1.3\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.Base">
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Base.25.0.0.0\lib\MonoAndroid41\Xamarin.GooglePlayServices.Base.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.Maps">
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Maps.25.0.0.0\lib\MonoAndroid41\Xamarin.GooglePlayServices.Maps.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.Location">
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Location.25.0.0.0\lib\MonoAndroid41\Xamarin.GooglePlayServices.Location.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="FusedLocationHandler.cs" />
+    <Compile Include="MvxAndroidFusedLocationWatcher.cs" />
+    <Compile Include="Plugin.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MvvmCross.Plugins.Location\MvvmCross.Plugins.Location.csproj">
+      <Project>{8B0A9E43-E90F-455C-AE56-45BC70429167}</Project>
+      <Name>MvvmCross.Plugins.Location</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/Location/MvvmCross.Plugins.Location.Fused.Droid/MvvmCross.Plugins.Location.Fused.Droid.csproj
+++ b/Location/MvvmCross.Plugins.Location.Fused.Droid/MvvmCross.Plugins.Location.Fused.Droid.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
+    <OutputPath>..\..\bin\Debug\Mvx\Droid\</OutputPath>
     <DefineConstants>DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
+    <OutputPath>..\..\bin\Release\Mvx\Droid\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>

--- a/Location/MvvmCross.Plugins.Location.Fused.Droid/MvvmCross.Plugins.Location.Fused.Droid.csproj
+++ b/Location/MvvmCross.Plugins.Location.Fused.Droid/MvvmCross.Plugins.Location.Fused.Droid.csproj
@@ -67,13 +67,16 @@
       <HintPath>..\..\packages\Xamarin.Android.Support.v4.23.0.1.3\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Base">
-      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Base.25.0.0.0\lib\MonoAndroid41\Xamarin.GooglePlayServices.Base.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Base.29.0.0.1\lib\MonoAndroid41\Xamarin.GooglePlayServices.Base.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Maps">
-      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Maps.25.0.0.0\lib\MonoAndroid41\Xamarin.GooglePlayServices.Maps.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Maps.29.0.0.1\lib\MonoAndroid41\Xamarin.GooglePlayServices.Maps.dll</HintPath>
     </Reference>
     <Reference Include="Xamarin.GooglePlayServices.Location">
-      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Location.25.0.0.0\lib\MonoAndroid41\Xamarin.GooglePlayServices.Location.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Location.29.0.0.1\lib\MonoAndroid41\Xamarin.GooglePlayServices.Location.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.GooglePlayServices.Basement">
+      <HintPath>..\..\packages\Xamarin.GooglePlayServices.Basement.29.0.0.1\lib\MonoAndroid41\Xamarin.GooglePlayServices.Basement.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Location/MvvmCross.Plugins.Location.Fused.Droid/MvxAndroidFusedLocationWatcher.cs
+++ b/Location/MvvmCross.Plugins.Location.Fused.Droid/MvxAndroidFusedLocationWatcher.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Threading;
+using Android.Content;
+using MvvmCross.Platform;
+using MvvmCross.Platform.Platform;
+using MvvmCross.Platform.Exceptions;
+using MvvmCross.Platform.Droid;
+using MvvmCross.Platform.Droid.Platform;
+
+namespace MvvmCross.Plugins.Location.Fused.Droid
+{
+	public class MvxAndroidFusedLocationWatcher
+		: MvxLocationWatcher
+	{
+		private Context _context;
+		private Context Context
+		{
+			get { return _context ?? (_context = Mvx.Resolve<IMvxAndroidGlobals> ().ApplicationContext); }
+		}
+
+		private FusedLocationHandler _locationHandler;
+
+		public MvxAndroidFusedLocationWatcher ()
+		{
+		}
+
+		protected override void PlatformSpecificStart (MvxLocationOptions options)
+		{
+			if (_locationHandler == null) {
+				_locationHandler = new FusedLocationHandler (this, Context);
+			}
+
+			_locationHandler.Start (options);
+		}
+
+		protected override void PlatformSpecificStop ()
+		{
+			_locationHandler.Stop ();
+		}
+
+		public override MvxGeoLocation CurrentLocation 
+		{
+			get 
+			{
+				if (_locationHandler == null)
+					throw new MvxException("Location Manager not started");
+
+				var androidLocation = _locationHandler.GetLastKnownLocation();
+				if (androidLocation == null)
+					return null;
+
+				return CreateLocation(androidLocation);
+			}
+		}
+
+		internal void OnLocationUpdated (Android.Locations.Location androidLocation)
+		{
+			if (androidLocation == null)
+			{
+				MvxTrace.Trace("Android: Null location seen");
+				return;
+			}
+
+			if (androidLocation.Latitude == double.MaxValue
+				|| androidLocation.Longitude == double.MaxValue)
+			{
+				MvxTrace.Trace("Android: Invalid location seen");
+				return;
+			}
+
+			MvxGeoLocation location;
+			try
+			{
+				location = CreateLocation(androidLocation);
+			}
+			catch (ThreadAbortException)
+			{
+				throw;
+			}
+			catch (Exception exception)
+			{
+				MvxTrace.Trace("Android: Exception seen in converting location " + exception.ToLongString());
+				return;
+			}
+
+			SendLocation (location);
+		}
+
+		internal void OnLocationError (MvxLocationErrorCode errorCode)
+		{
+			SendError (errorCode);
+		}
+
+		internal void OnLocationAvailabilityChanged (bool isAvailable)
+		{
+			Permission = isAvailable ? MvxLocationPermission.Granted : MvxLocationPermission.Denied;
+		}
+
+		private static MvxGeoLocation CreateLocation(Android.Locations.Location androidLocation)
+		{
+			var position = new MvxGeoLocation { Timestamp = androidLocation.Time.FromMillisecondsUnixTimeToUtc() };
+			var coords = position.Coordinates;
+
+			if (androidLocation.HasAltitude)
+				coords.Altitude = androidLocation.Altitude;
+
+			if (androidLocation.HasBearing)
+				coords.Heading = androidLocation.Bearing;
+
+			coords.Latitude = androidLocation.Latitude;
+			coords.Longitude = androidLocation.Longitude;
+			if (androidLocation.HasSpeed)
+				coords.Speed = androidLocation.Speed;
+			if (androidLocation.HasAccuracy)
+			{
+				coords.Accuracy = androidLocation.Accuracy;
+			}
+
+			return position;
+		}
+	}
+}
+

--- a/Location/MvvmCross.Plugins.Location.Fused.Droid/Plugin.cs
+++ b/Location/MvvmCross.Plugins.Location.Fused.Droid/Plugin.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using MvvmCross.Platform;
+using MvvmCross.Platform.Plugins;
+
+namespace MvvmCross.Plugins.Location.Fused.Droid
+{
+	public class Plugin
+		: IMvxPlugin
+	{
+		public void Load()
+		{
+			Mvx.RegisterSingleton<IMvxLocationWatcher>(() => new MvxAndroidFusedLocationWatcher());
+		}
+	}
+}
+

--- a/Location/MvvmCross.Plugins.Location.Fused.Droid/Properties/AssemblyInfo.cs
+++ b/Location/MvvmCross.Plugins.Location.Fused.Droid/Properties/AssemblyInfo.cs
@@ -1,0 +1,37 @@
+﻿// AssemblyInfo.cs
+// (c) Copyright Cirrious Ltd. http://www.cirrious.com
+// MvvmCross is licensed using Microsoft Public License (Ms-PL)
+// Contributions and inspirations noted in readme.md and license.txt
+// 
+// Project Lead - Stuart Lodge, @slodge, me@slodge.com
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+
+[assembly: AssemblyTitle("MvvmCross.Plugins.Location.Fused.Droid")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Cirrious")]
+[assembly: AssemblyProduct("MvvmCross.Plugins.Location.Fused.Droid")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]

--- a/Location/MvvmCross.Plugins.Location.Fused.Droid/packages.config
+++ b/Location/MvvmCross.Plugins.Location.Fused.Droid/packages.config
@@ -4,7 +4,8 @@
   <package id="MvvmCross.Core" version="4.1.0" targetFramework="MonoAndroid50" />
   <package id="MvvmCross.Platform" version="4.1.0" targetFramework="MonoAndroid50" />
   <package id="Xamarin.Android.Support.v4" version="23.0.1.3" targetFramework="MonoAndroid50" />
-  <package id="Xamarin.GooglePlayServices.Base" version="25.0.0.0" targetFramework="MonoAndroid50" />
-  <package id="Xamarin.GooglePlayServices.Location" version="25.0.0.0" targetFramework="MonoAndroid50" />
-  <package id="Xamarin.GooglePlayServices.Maps" version="25.0.0.0" targetFramework="MonoAndroid50" />
+  <package id="Xamarin.GooglePlayServices.Base" version="29.0.0.1" targetFramework="MonoAndroid50" />
+  <package id="Xamarin.GooglePlayServices.Basement" version="29.0.0.1" targetFramework="MonoAndroid50" />
+  <package id="Xamarin.GooglePlayServices.Location" version="29.0.0.1" targetFramework="MonoAndroid50" />
+  <package id="Xamarin.GooglePlayServices.Maps" version="29.0.0.1" targetFramework="MonoAndroid50" />
 </packages>

--- a/Location/MvvmCross.Plugins.Location.Fused.Droid/packages.config
+++ b/Location/MvvmCross.Plugins.Location.Fused.Droid/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MvvmCross.Binding" version="4.1.0" targetFramework="MonoAndroid50" />
+  <package id="MvvmCross.Core" version="4.1.0" targetFramework="MonoAndroid50" />
+  <package id="MvvmCross.Platform" version="4.1.0" targetFramework="MonoAndroid50" />
+  <package id="Xamarin.Android.Support.v4" version="23.0.1.3" targetFramework="MonoAndroid50" />
+  <package id="Xamarin.GooglePlayServices.Base" version="25.0.0.0" targetFramework="MonoAndroid50" />
+  <package id="Xamarin.GooglePlayServices.Location" version="25.0.0.0" targetFramework="MonoAndroid50" />
+  <package id="Xamarin.GooglePlayServices.Maps" version="25.0.0.0" targetFramework="MonoAndroid50" />
+</packages>

--- a/MvvmCross.Plugins.sln
+++ b/MvvmCross.Plugins.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Accelerometer", "Accelerometer", "{D9F520C0-4C25-465B-9C16-CADDDE3E72B8}"
 EndProject
@@ -298,6 +298,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MvvmCross.Plugins.WebBrowser.Wpf", "WebBrowser\MvvmCross.Plugins.WebBrowser.Wpf\MvvmCross.Plugins.WebBrowser.Wpf.csproj", "{3BD0462A-71C0-4240-A780-0C0BD284A0D5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MvvmCross.Plugins.Sqlite.WindowsPhone", "SQLite-PCL\MvvmCross.Plugins.Sqlite.WindowsPhone\MvvmCross.Plugins.Sqlite.WindowsPhone.csproj", "{E7CC2E25-7F05-42BC-9FF6-34A9A28D02C7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MvvmCross.Plugins.Location.Fused.Droid", "Location\MvvmCross.Plugins.Location.Fused.Droid\MvvmCross.Plugins.Location.Fused.Droid.csproj", "{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -2279,6 +2281,22 @@ Global
 		{E7CC2E25-7F05-42BC-9FF6-34A9A28D02C7}.Release|x64.Build.0 = Release|Any CPU
 		{E7CC2E25-7F05-42BC-9FF6-34A9A28D02C7}.Release|x86.ActiveCfg = Release|x86
 		{E7CC2E25-7F05-42BC-9FF6-34A9A28D02C7}.Release|x86.Build.0 = Release|x86
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Debug|ARM.Build.0 = Debug|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Debug|x64.Build.0 = Debug|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Debug|x86.Build.0 = Debug|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Release|ARM.ActiveCfg = Release|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Release|ARM.Build.0 = Release|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Release|x64.ActiveCfg = Release|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Release|x64.Build.0 = Release|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2407,5 +2425,6 @@ Global
 		{8AE35C8E-CC76-4E4C-98F8-CA68FBCB550B} = {8D6F4620-D8BD-4E14-B698-4998138EEA32}
 		{3BD0462A-71C0-4240-A780-0C0BD284A0D5} = {E7C40E91-1D44-4CE7-A137-3C444738E94F}
 		{E7CC2E25-7F05-42BC-9FF6-34A9A28D02C7} = {9B45C8EC-18B9-4A88-950E-8D8FF8FAA1DA}
+		{6F1EEC6C-49B6-4710-AD52-8EBAEBBFEB85} = {B5BE527E-B554-4A0F-9627-62E0F2DD8889}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Initial implementation of Fused Location Provider #84. See:
- https://developer.android.com/training/location/retrieve-current.html
- http://www.tothenew.com/blog/googles-fused-location-api-for-android/

**ToDo**
- [x] Add project to the solution (I use only XS and it modifies all csproj files)
- [x] Setup nuspec
- [x] Load plugin on startup (plugin name doesn't fit lookup convention)

**Bootstrap issue**
Plugin has the name MvvmCross.Plugins.Location.Fused.Droid (note **Fused** before **Droid**). Plugin loader fails with lookup of MvvmCross.Plugins.Location.Droid. How to solve it? Emit **Fused** in the namespace/DLL? Modify plugin loader to support the case MvvmCross.Plugins.PluginName.**Stuff**.Droid?
