### PR TITLE
Fixed queuing unindexed files

### DIFF
--- a/DownloadCache/MvvmCross.Plugins.DownloadCache/MvxFileDownloadCache.cs
+++ b/DownloadCache/MvvmCross.Plugins.DownloadCache/MvxFileDownloadCache.cs
@@ -130,7 +130,7 @@ namespace MvvmCross.Plugins.DownloadCache
             var cachedFiles = new Dictionary<string, Entry>();
             foreach (var e in _entriesByHttpUrl)
             {
-                cachedFiles[e.Value.DownloadedPath] = e.Value;
+                cachedFiles[store.NativePath(e.Value.DownloadedPath)] = e.Value;
             }
 
             var toDelete = new List<string>();


### PR DESCRIPTION
Every time when <code>QueueUnindexedFilesForDelete</code> method was called, every file was queued for deletion. It was caused by not using absolute path in <code>DownloadPath</code>.
