### PR TITLE
Feature/content url loader

### DIFF
--- a/DownloadCache/MvvmCross.Plugins.DownloadCache.Droid/MvxAndroidLocalFileImageLoader.cs
+++ b/DownloadCache/MvvmCross.Plugins.DownloadCache.Droid/MvxAndroidLocalFileImageLoader.cs
@@ -82,7 +82,7 @@ namespace MvvmCross.Plugins.DownloadCache.Droid
                 // There is no Async version of DecodeFileDescriptor that
                 // takes Options object. Wrapping with a Task Factory
                 // to maintain async nature of the method call
-                await Task.Factory.StartNew(() =>
+                await Task.Run(() =>
                 {
                     var globals = Mvx.Resolve<IMvxAndroidGlobals>();
                     var uri = Android.Net.Uri.Parse(localPath);


### PR DESCRIPTION
Trying to retrieve an image from an Android device using a ContentResolver causes a FileNotFoundException when the url is passed to an MvxImageView ImageUrl property when the localPath is in the format "content://media/external/images/media/47". This change updates the MvxAndroidLocalFileImageLoader to look for this scenario and, when found, utilizes a FileDescriptor created from the ContentResolver to decode the bitmap.

```
// Code which brought this to light which selects a random image from the device images gallery
// Result sets _lastImage to the image url in the form of content://media/external/images/media/47

var context = _globals.ApplicationContext;
                var cursor = context?.ContentResolver.Query(
                    MediaStore.Images.Media.ExternalContentUri,
                    ImagesQuery.Projection,
                    MediaStore.Images.Media.InterfaceConsts.BucketDisplayName + " NOT LIKE '%Screenshots%'",
                    null, null);

var count = cursor?.Count;
if (!count.HasValue || count.Value <= 0) return;

var random = new Random();
while (true) {
                    cursor.MoveToPosition(random.NextInt(count.Value));
                    var imageUri = ContentUris.WithAppendedId(MediaStore.Images.Media.ExternalContentUri,
                        cursor.GetLong(ImagesQuery.Id));

                    if (imageUri.ToString().Equals(_lastImage)) continue;

                    _lastImage = imageUri.ToString();
                    break;
                }
```
