### PR TITLE
Added missing interface declaration for legacy MakeRequestFor method

### DIFF
--- a/Network/MvvmCross.Plugins.Network/Rest/IMvxJsonRestClient.cs
+++ b/Network/MvvmCross.Plugins.Network/Rest/IMvxJsonRestClient.cs
@@ -16,6 +16,8 @@ namespace MvvmCross.Plugins.Network.Rest
     {
         Func<IMvxJsonConverter> JsonConverterProvider { get; set; }
 
+        IMvxAbortable MakeRequestFor<T>(MvxRestRequest restRequest, Action<MvxDecodedRestResponse<T>> successAction, Action<Exception> errorAction);
+
         Task<MvxDecodedRestResponse<T>> MakeRequestForAsync<T>(MvxRestRequest restRequest, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/Network/MvvmCross.Plugins.Network/Rest/IMvxRestClient.cs
+++ b/Network/MvvmCross.Plugins.Network/Rest/IMvxRestClient.cs
@@ -17,6 +17,9 @@ namespace MvvmCross.Plugins.Network.Rest
 
         void SetSetting(string key, object value);
 
+        IMvxAbortable MakeRequest(MvxRestRequest restRequest, Action<MvxRestResponse> successAction, Action<Exception> errorAction);
+        IMvxAbortable MakeRequest(MvxRestRequest restRequest, Action<MvxStreamRestResponse> successAction, Action<Exception> errorAction);
+
         Task<MvxRestResponse> MakeRequestAsync(MvxRestRequest restRequest, CancellationToken cancellationToken = default(CancellationToken));
         Task<MvxStreamRestResponse> MakeStreamRequestAsync(MvxRestRequest restRequest, CancellationToken cancellationToken = default(CancellationToken));
     }


### PR DESCRIPTION
**This pull requests is targeting the Network plugin.**

It just restores backward compatibility first introduced with commit 0d3c9f85bd9cecb4090174a198dee68e3c29d17d.

It seems that while reimplementing the `MakeRequestFor` method in `MvxJsonRestClient` (see https://github.com/MvvmCross/MvvmCross-Plugins/commit/0d3c9f85bd9cecb4090174a198dee68e3c29d17d#diff-08a8fbb0ffcd558a32b4ec05ba903865R23) the interface declaration was forgotten.

The same is true for the `MakeRequest` methods of `MvxRestClient`.
