### PR TITLE
Lazy register IMvxFileDownloadCache within DownloadCache plugin Load

### DIFF
--- a/DownloadCache/MvvmCross.Plugins.DownloadCache.Droid/Plugin.cs
+++ b/DownloadCache/MvvmCross.Plugins.DownloadCache.Droid/Plugin.cs
@@ -33,10 +33,8 @@ namespace MvvmCross.Plugins.DownloadCache.Droid
         {
             Mvx.RegisterSingleton<IMvxHttpFileDownloader>(() => CreateHttpFileDownloader());
 
-            var fileDownloadCache = CreateFileDownloadCache();
-
-            Mvx.RegisterSingleton<IMvxFileDownloadCache>(fileDownloadCache);
-            Mvx.RegisterSingleton<IMvxImageCache<Bitmap>>(() => CreateCache(fileDownloadCache));
+            Mvx.RegisterSingleton<IMvxFileDownloadCache>(CreateFileDownloadCache);
+            Mvx.RegisterSingleton<IMvxImageCache<Bitmap>>(CreateCache);
             Mvx.RegisterType<IMvxImageHelper<Bitmap>, MvxDynamicImageHelper<Bitmap>>();
             Mvx.RegisterSingleton<IMvxLocalFileImageLoader<Bitmap>>(() => new MvxAndroidLocalFileImageLoader());
         }
@@ -58,11 +56,11 @@ namespace MvvmCross.Plugins.DownloadCache.Droid
             return fileDownloadCache;
         }
 
-        private MvxImageCache<Bitmap> CreateCache(IMvxFileDownloadCache fileDownloadCache)
+        private MvxImageCache<Bitmap> CreateCache()
         {
             var configuration = _configuration ?? MvxDownloadCacheConfiguration.Default;
 
-
+            var fileDownloadCache = Mvx.Resolve<IMvxFileDownloadCache>();
             var fileCache = new MvxImageCache<Bitmap>(fileDownloadCache, configuration.MaxInMemoryFiles, configuration.MaxInMemoryBytes, configuration.DisposeOnRemoveFromCache);
             return fileCache;
         }

--- a/DownloadCache/MvvmCross.Plugins.DownloadCache.iOS/Plugin.cs
+++ b/DownloadCache/MvvmCross.Plugins.DownloadCache.iOS/Plugin.cs
@@ -33,10 +33,8 @@ namespace MvvmCross.Plugins.DownloadCache.iOS
         {
             Mvx.RegisterSingleton<IMvxHttpFileDownloader>(CreateHttpFileDownloader);
 
-            var fileDownloadCache = CreateFileDownloadCache();
-
-            Mvx.RegisterSingleton<IMvxFileDownloadCache>(fileDownloadCache);
-            Mvx.RegisterSingleton<IMvxImageCache<UIImage>>(CreateCache(fileDownloadCache));
+            Mvx.RegisterSingleton<IMvxFileDownloadCache>(CreateFileDownloadCache);
+            Mvx.RegisterSingleton<IMvxImageCache<UIImage>>(CreateCache);
             Mvx.RegisterType<IMvxImageHelper<UIImage>, MvxDynamicImageHelper<UIImage>>();
             Mvx.RegisterSingleton<IMvxLocalFileImageLoader<UIImage>>(() => new MvxIosLocalFileImageLoader());
         }
@@ -47,9 +45,10 @@ namespace MvvmCross.Plugins.DownloadCache.iOS
             return new MvxHttpFileDownloader(configuration.MaxConcurrentDownloads);
         }
 
-        private MvxImageCache<UIImage> CreateCache(IMvxFileDownloadCache fileDownloadCache)
+        private MvxImageCache<UIImage> CreateCache()
         {
             var configuration = _configuration ?? MvxDownloadCacheConfiguration.Default;
+            var fileDownloadCache = Mvx.Resolve<IMvxFileDownloadCache>();
             var fileCache = new MvxImageCache<UIImage>(fileDownloadCache, configuration.MaxInMemoryFiles, configuration.MaxInMemoryBytes, configuration.DisposeOnRemoveFromCache);
             return fileCache;
         }

--- a/nuspec/MvvmCross.Plugin.DownloadCache.nuspec
+++ b/nuspec/MvvmCross.Plugin.DownloadCache.nuspec
@@ -34,6 +34,7 @@ This package contains the 'DownloadCache' plugin for MvvmCross</description>
 			<group targetFramework="MonoAndroid">
 				<dependency id="MvvmCross.Platform" version="4.2.3" />
 				<dependency id="MvvmCross.Binding" version="4.2.3" />
+				<dependency id="System.Collections.Immutable" version="1.2.0" />
 				<dependency id="Xamarin.Android.Support.v4" version="23.4.0" />
 			</group>
 			<group targetFramework="Xamarin.Mac20">


### PR DESCRIPTION
Plugin load tried to instantiate MvxFileDownloadCache which looked up for an implementation
from File plugin that has not been loaded yet.
The solution is to lazy register IMvxFileDownloadCache instead and give time for
bootstrap loader to register File plugin.

Fixes #119 
