### PR TITLE
Made sure that we use the settings in the 'new' DeserializeObject met…

### DIFF
--- a/Json/MvvmCross.Plugins.Json/MvxJsonConverter.cs
+++ b/Json/MvvmCross.Plugins.Json/MvxJsonConverter.cs
@@ -48,7 +48,7 @@ namespace MvvmCross.Plugins.Json
 
         public T DeserializeObject<T>(Stream stream)
         {
-            var serializer = new JsonSerializer();
+			var serializer = JsonSerializer.Create(Settings);
 
             using (var sr = new StreamReader(stream))
             using (var jsonTextReader = new JsonTextReader(sr))

--- a/Json/MvvmCross.Plugins.Json/MvxJsonConverter.cs
+++ b/Json/MvvmCross.Plugins.Json/MvxJsonConverter.cs
@@ -5,11 +5,11 @@
 //
 // Project Lead - Stuart Lodge, @slodge, me@slodge.com
 
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using MvvmCross.Platform.Platform;
+using Newtonsoft.Json;
 
 namespace MvvmCross.Plugins.Json
 {


### PR DESCRIPTION
In the current implementation of the MvxJsonConverter the DerializeObject which takes a Stream as paramter does not take into account the created settings object. 

Creating the JsonSerializer (to use the settings) should be done via the factory method. 
http://www.newtonsoft.com/json/help/html/M_Newtonsoft_Json_JsonSerializer_Create_1.htm
