### PR TITLE
Remove files from delete queue after they've been deleted

### DIFF
--- a/DownloadCache/MvvmCross.Plugins.DownloadCache/MvxFileDownloadCache.cs
+++ b/DownloadCache/MvvmCross.Plugins.DownloadCache/MvxFileDownloadCache.cs
@@ -227,6 +227,8 @@ namespace MvvmCross.Plugins.DownloadCache
                 var fileService = MvxFileStoreHelper.SafeGetFileStore();
                 if (fileService.Exists(nextFileToDelete))
                     fileService.DeleteFile(nextFileToDelete);
+
+                _toDeleteFiles.Remove(nextFileToDelete);
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
Items were never removed from `_toDeleteFiles`, so `DeleteNextUnneededFile` would only try to deleted the last file added to the list over and over again.
